### PR TITLE
Ircii Manpath / Makefile jobs fix (this time with proper commit)

### DIFF
--- a/Library/Formula/ircii.rb
+++ b/Library/Formula/ircii.rb
@@ -10,7 +10,8 @@ class Ircii <Formula
                           "--disable-debug",
                           "--disable-dependency-tracking",
                           "--with-default-server=irc.freenode.net",
+                          "--mandir=#{prefix}/share/man",
                           "--enable-ipv6"
-    system "make install"
+    system "make install -j1" # makefile is not multi-job safe
   end
 end


### PR DESCRIPTION
ircii didn't build for me as make was running multiple jobs at once, causing the manpath directory to be created after it needed to be used.

Furthermore, it installed to $prefix/man rather than $prefix/share/man as desire
